### PR TITLE
GitHub PagesのプレビューURLをDeploymentとして表示する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.sha,
+              ref: context.payload.pull_request.head.sha,
               environment: 'pr-preview',
               auto_merge: false,
               required_contexts: [],


### PR DESCRIPTION
Issue #7 の対応です。プルリクエスト時にGitHub Pagesのプレビュー環境へのリンクをDeploymentとして表示するようにしました。これにより、GitHub上から直接プレビューにアクセスできるようになります。