### PR TITLE
divide-crop-gui: トップバーの見た目をarrange-guiに合わせる

### DIFF
--- a/divide-crop-gui/src/App.jsx
+++ b/divide-crop-gui/src/App.jsx
@@ -198,10 +198,10 @@ function App() {
           <span className="image-count">
             {images.length}{t('imageCount')}
           </span>
-          <button onClick={toggleLanguage} className="icon-btn">
+          <button onClick={toggleLanguage} className="lang-toggle">
             {language === 'en' ? 'JA' : 'EN'}
           </button>
-          <button onClick={toggleTheme} className="icon-btn">
+          <button onClick={toggleTheme} title="テーマ切り替え">
             {theme === 'dark' ? '☀️' : '🌙'}
           </button>
         </div>


### PR DESCRIPTION
divide-crop-guiのトップバーのボタンのスタイル(背景色や間隔)をarrange-guiと統一しました。

- 言語切り替えボタンとテーマ切り替えボタンのクラスを修正
- アイコンボタンスタイルから通常のボタンスタイルへ変更