### PR TITLE
自動倍率モード機能追加 (kiro-auto-plan)

### DIFF
--- a/arrange-gui/src/App.jsx
+++ b/arrange-gui/src/App.jsx
@@ -30,6 +30,7 @@ function App() {
   // Display state
   const [imageSize, setImageSize] = useState(100);
   const [autoFitSize, setAutoFitSize] = useState(100);
+  const [autoZoomMode, setAutoZoomMode] = useState(true);
   const [activeArea, setActiveArea] = useState('main'); // 'main' | 'trash'
   const [trashFocusIndex, setTrashFocusIndex] = useState(0);
 
@@ -95,6 +96,7 @@ function App() {
 
   // Calculate auto-fit size when images load or trash visibility changes
   useEffect(() => {
+    if (!autoZoomMode) return;
     if (images.length > 0 && containerRef.current) {
       const containerWidth = containerRef.current.offsetWidth - 40;
       // Reserve space: 150 if no trash, 300 if trash logic
@@ -119,7 +121,7 @@ function App() {
         }
       }
     }
-  }, [images.length, trashImages.length]);
+  }, [images.length, trashImages.length, autoZoomMode]);
 
   // Show message temporarily
   const showMessage = useCallback((msg) => {
@@ -434,14 +436,17 @@ function App() {
 
   // Zoom controls
   const handleZoomIn = useCallback(() => {
+    setAutoZoomMode(false);
     setImageSize(prev => Math.min(300, prev + 20));
   }, []);
 
   const handleZoomOut = useCallback(() => {
+    setAutoZoomMode(false);
     setImageSize(prev => Math.max(50, prev - 20));
   }, []);
 
   const handleZoomReset = useCallback(() => {
+    setAutoZoomMode(true);
     setImageSize(autoFitSize);
   }, [autoFitSize]);
 

--- a/arrange-gui/tests/sticker-gui.spec.js
+++ b/arrange-gui/tests/sticker-gui.spec.js
@@ -85,4 +85,41 @@ test.describe('Sticker GUI (English)', () => {
         await page.click('button.lang-toggle');
         await expect(page.getByRole('button', { name: 'Add Images' })).toBeVisible();
     });
+
+    test('should support auto-zoom mode', async ({ page }) => {
+        // Upload multiple images
+        const files = Array.from({ length: 8 }, (_, i) => ({
+            name: `sticker${i}.png`,
+            mimeType: 'image/png',
+            buffer: createDummyPng(),
+        }));
+        await page.locator('input[type="file"]').setInputFiles(files);
+        await expect(page.locator('.image-tile')).toHaveCount(9); // 8 images + 1 dummy
+
+        // Get initial image size (auto-zoom mode is enabled by default)
+        const initialSize = await page.locator('.image-tile').first().evaluate(el => el.offsetWidth);
+
+        // Manual zoom in (Ctrl++) - should disable auto-zoom mode
+        await page.keyboard.press('Control++');
+        const manualSize = await page.locator('.image-tile').first().evaluate(el => el.offsetWidth);
+        expect(manualSize).toBeGreaterThan(initialSize);
+
+        // Add more images - size should NOT change significantly (auto-zoom mode is disabled)
+        const moreFiles = Array.from({ length: 2 }, (_, i) => ({
+            name: `sticker${i + 8}.png`,
+            mimeType: 'image/png',
+            buffer: createDummyPng(),
+        }));
+        await page.locator('input[type="file"]').setInputFiles(moreFiles);
+        await expect(page.locator('.image-tile')).toHaveCount(11); // 10 images + 1 dummy
+        const sizeAfterAdd = await page.locator('.image-tile').first().evaluate(el => el.offsetWidth);
+        // Size should be close to manual size (within 10px tolerance for grid adjustments)
+        expect(Math.abs(sizeAfterAdd - manualSize)).toBeLessThan(10);
+
+        // Reset zoom (Ctrl+0) - should re-enable auto-zoom mode
+        await page.keyboard.press('Control+0');
+        const resetSize = await page.locator('.image-tile').first().evaluate(el => el.offsetWidth);
+        // After reset, size should be recalculated to fit all images
+        expect(resetSize).toBeLessThan(manualSize); // Should be smaller to fit more images
+    });
 });


### PR DESCRIPTION
## 概要
arrange-guiのスタンプ配置ツールに自動倍率モード機能を追加しました。

## 変更内容
- **自動倍率モードフラグ**: 内部状態として`autoZoomMode`を管理（UI表示なし）
- **起動時の動作**: 自動倍率モードは有効（`true`）
- **Ctrl+0の動作**: 全画像が画面に収まるように自動調整し、自動倍率モードを有効化
- **手動倍率変更**: Ctrl++/Ctrl+;/Ctrl+-で倍率変更時、自動倍率モードを無効化（`false`）
- **ゴミ箱表示時**: 自動倍率モードが有効な場合のみ、倍率を自動調整

## 動作確認方法
1. アプリを起動し、画像を複数枚読み込む → 全画像が画面に収まる倍率で表示される
2. Ctrl++で倍率を手動変更 → 自動倍率モードが解除される
3. 画像を追加またはゴミ箱に移動 → 倍率が変更されない（手動モードのため）
4. Ctrl+0を押す → 全画像が画面に収まる倍率に自動調整され、自動倍率モードが再有効化される
5. 画像を追加またはゴミ箱に移動 → 倍率が自動調整される（自動モードのため）

## 技術的な詳細
- `App.jsx`に`autoZoomMode`状態を追加
- 自動倍率計算の`useEffect`に条件分岐を追加
- `handleZoomIn`/`handleZoomOut`で自動モードを解除
- `handleZoomReset`で自動モードを有効化