### PR TITLE
feat: opencode-kimi-k25-plan - 自動倍率モードの導入

### DIFF
--- a/arrange-gui/src/App.jsx
+++ b/arrange-gui/src/App.jsx
@@ -30,6 +30,7 @@ function App() {
   // Display state
   const [imageSize, setImageSize] = useState(100);
   const [autoFitSize, setAutoFitSize] = useState(100);
+  const [isAutoZoom, setIsAutoZoom] = useState(true);
   const [activeArea, setActiveArea] = useState('main'); // 'main' | 'trash'
   const [trashFocusIndex, setTrashFocusIndex] = useState(0);
 
@@ -113,13 +114,16 @@ function App() {
         const totalHeight = rows * (size + 8);
         if (totalHeight <= containerHeight && cols >= 1) {
           setAutoFitSize(size);
-          setImageSize(size);
+          // Only update imageSize if auto-zoom mode is enabled
+          if (isAutoZoom) {
+            setImageSize(size);
+          }
           // If we found a fit, break
           break;
         }
       }
     }
-  }, [images.length, trashImages.length]);
+  }, [images.length, trashImages.length, isAutoZoom]);
 
   // Show message temporarily
   const showMessage = useCallback((msg) => {
@@ -434,14 +438,17 @@ function App() {
 
   // Zoom controls
   const handleZoomIn = useCallback(() => {
+    setIsAutoZoom(false);
     setImageSize(prev => Math.min(300, prev + 20));
   }, []);
 
   const handleZoomOut = useCallback(() => {
+    setIsAutoZoom(false);
     setImageSize(prev => Math.max(50, prev - 20));
   }, []);
 
   const handleZoomReset = useCallback(() => {
+    setIsAutoZoom(true);
     setImageSize(autoFitSize);
   }, [autoFitSize]);
 

--- a/arrange-gui/tests/sticker-gui.spec.js
+++ b/arrange-gui/tests/sticker-gui.spec.js
@@ -60,6 +60,80 @@ test.describe('Sticker GUI (Japanese)', () => {
         await expect(page.locator('.badge.tab')).toBeVisible();
         await expect(page.getByText('タブ✓')).toBeVisible();
     });
+
+    test('should hide trash area initially and show when images are deleted', async ({ page }) => {
+        const files = Array.from({ length: 2 }, (_, i) => ({
+            name: `sticker${i}.png`,
+            mimeType: 'image/png',
+            buffer: createDummyPng(),
+        }));
+        await page.locator('input[type="file"]').setInputFiles(files);
+
+        // Initially trash should not be visible
+        await expect(page.locator('.trash-area')).not.toBeVisible();
+
+        // Delete first image
+        await page.keyboard.press('Delete');
+
+        // Trash should now be visible
+        await expect(page.locator('.trash-area')).toBeVisible();
+    });
+
+    test('should reset zoom with Ctrl+0 and enable auto-zoom mode', async ({ page }) => {
+        const files = Array.from({ length: 2 }, (_, i) => ({
+            name: `sticker${i}.png`,
+            mimeType: 'image/png',
+            buffer: createDummyPng(),
+        }));
+        await page.locator('input[type="file"]').setInputFiles(files);
+
+        // First zoom in manually
+        await page.keyboard.press('Control+;');
+
+        // Get current size
+        const tile = page.locator('.image-tile').first();
+        const sizeBefore = await tile.evaluate(el => el.style.width);
+
+        // Press Ctrl+0 to reset
+        await page.keyboard.press('Control+0');
+
+        // Size should change (auto-fit)
+        await page.waitForTimeout(100);
+        const sizeAfter = await tile.evaluate(el => el.style.width);
+        expect(sizeAfter).not.toBe(sizeBefore);
+    });
+
+    test('should disable auto-zoom mode when zooming manually', async ({ page }) => {
+        const files = Array.from({ length: 2 }, (_, i) => ({
+            name: `sticker${i}.png`,
+            mimeType: 'image/png',
+            buffer: createDummyPng(),
+        }));
+        await page.locator('input[type="file"]').setInputFiles(files);
+
+        // Get initial size
+        const tile = page.locator('.image-tile').first();
+        const initialSize = await tile.evaluate(el => el.style.width);
+
+        // Zoom in manually with Ctrl+;
+        await page.keyboard.press('Control+;');
+        await page.waitForTimeout(100);
+        const sizeAfterZoomIn = await tile.evaluate(el => el.style.width);
+
+        // Size should have increased
+        expect(parseInt(sizeAfterZoomIn)).toBeGreaterThan(parseInt(initialSize));
+
+        // Delete an image to trigger trash visibility
+        await page.keyboard.press('Delete');
+
+        // Wait for trash to appear
+        await expect(page.locator('.trash-area')).toBeVisible();
+
+        // Since auto-zoom is disabled, size should NOT change after trash appears
+        await page.waitForTimeout(100);
+        const sizeAfterTrash = await tile.evaluate(el => el.style.width);
+        expect(sizeAfterTrash).toBe(sizeAfterZoomIn);
+    });
 });
 
 test.describe('Sticker GUI (English)', () => {


### PR DESCRIPTION
スタンプ配置ツールに自動倍率モードを導入し、より直感的なズーム操作を実現しました。

## 主な変更点

### 機能追加
- 自動倍率モードフラグの導入（起動直後は有効）
- Ctrl+0: 自動倍率モードを有効にし、すべての画像が画面に収まるサイズに自動調整
- Ctrl++/Ctrl+;: 表示倍率を拡大し、自動倍率モードを解除
- Ctrl+-: 表示倍率を縮小し、自動倍率モードを解除
- ゴミ箱は起動直後は非表示、画像削除時に初めて表示
- 自動倍率モードON時のみ、ゴミ箱表示時にサイズを自動調整

### テスト追加
- 起動時にゴミ箱が非表示であること
- Ctrl+0で自動倍率モードが有効になること
- 手動ズームで自動倍率モードが解除されること
- ゴミ箱表示時のサイズ調整動作

## コミット
- bf898f3 feat: 自動倍率モードの導入
- 2e77c18 test: 自動倍率モードのテストを追加