### PR TITLE
GUI版背景除去で境界部分の背景色残りを修正

### DIFF
--- a/remove-bg-gui/src/utils/backgroundRemover.js
+++ b/remove-bg-gui/src/utils/backgroundRemover.js
@@ -70,8 +70,58 @@ export function fuzzToThreshold(fuzz) {
 }
 
 /**
+ * Apply morphological erosion to the alpha channel.
+ * This removes edge artifacts by eroding the non-transparent regions.
+ * Similar to ImageMagick's -morphology Erode Disk:2
+ * @param {ImageData} imageData - Canvas ImageData object (will be modified)
+ * @param {number} radius - Erosion radius (default: 2 for Disk:2)
+ */
+function erodeAlphaChannel(imageData, radius = 2) {
+    const { data, width, height } = imageData;
+    const alphaCopy = new Uint8ClampedArray(width * height);
+
+    // Copy alpha channel
+    for (let i = 0; i < width * height; i++) {
+        alphaCopy[i] = data[i * 4 + 3];
+    }
+
+    // Apply erosion: if any pixel in the neighborhood is transparent,
+    // make the center pixel transparent
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+            const idx = y * width + x;
+            let shouldErode = false;
+
+            // Check circular neighborhood (disk structuring element)
+            for (let dy = -radius; dy <= radius && !shouldErode; dy++) {
+                for (let dx = -radius; dx <= radius && !shouldErode; dx++) {
+                    // Check if within disk radius
+                    if (dx * dx + dy * dy > radius * radius) continue;
+
+                    const ny = y + dy;
+                    const nx = x + dx;
+
+                    // Check bounds
+                    if (ny >= 0 && ny < height && nx >= 0 && nx < width) {
+                        const nIdx = ny * width + nx;
+                        if (alphaCopy[nIdx] === 0) {
+                            shouldErode = true;
+                        }
+                    }
+                }
+            }
+
+            if (shouldErode) {
+                data[idx * 4 + 3] = 0;
+            }
+        }
+    }
+}
+
+/**
  * Remove background from image by making all matching-color pixels transparent.
  * Similar to ImageMagick's -transparent flag behavior.
+ * Includes alpha channel erosion to remove edge artifacts.
  * @param {ImageData} imageData - Canvas ImageData object (will be modified)
  * @param {{r: number, g: number, b: number}} bgColor - Background color to remove
  * @param {number} fuzz - Fuzz tolerance percentage (0-100)
@@ -99,6 +149,10 @@ export function removeBackground(imageData, bgColor, fuzz) {
             }
         }
     }
+
+    // Apply morphological erosion to remove edge artifacts
+    // This matches ImageMagick's -morphology Erode Disk:2 behavior
+    erodeAlphaChannel(imageData, 2);
 
     return imageData;
 }


### PR DESCRIPTION
CLI版のremove_bg.pyで使用しているImageMagickのと同様の処理をGUI版に実装しました。

## 変更内容
- 関数を追加し、Disk半径2の円形構造要素でモルフォロジー収縮を適用
- 背景色を透明にした後にアルファチャンネルの収縮処理を実行
- 境界部分に残る微妙な背景色を除去

## 動作確認
- 背景除去後の画像で境界部分の色がよりきれいに除去されるようになります
- CLI版と同様の処理結果が得られます