### PR TITLE
fix(arrange-gui): 最下行が不完全な場合の下矢印キー移動を修正

### DIFF
--- a/arrange-gui/src/App.jsx
+++ b/arrange-gui/src/App.jsx
@@ -491,15 +491,23 @@ function App() {
             newIndex = focusIndex - gridColumns;
           }
           break;
-        case 'down':
-          if (focusIndex + gridColumns <= maxIndex) {
-            newIndex = focusIndex + gridColumns;
-          } else if (trashImages.length > 0) {
-            setActiveArea('trash');
-            setTrashFocusIndex(0);
-            return;
+        case 'down': {
+          const targetIndex = focusIndex + gridColumns;
+          const lastRowStart = Math.floor(images.length / gridColumns) * gridColumns;
+
+          if (targetIndex <= maxIndex) {
+            newIndex = targetIndex;
+          } else if (focusIndex >= lastRowStart) {
+            if (trashImages.length > 0) {
+              setActiveArea('trash');
+              setTrashFocusIndex(0);
+              return;
+            }
+          } else {
+            newIndex = maxIndex;
           }
           break;
+        }
       }
 
       if (newIndex !== focusIndex) {


### PR DESCRIPTION
## 問題

最下行が途中で終わっている状態で、最下行から2行目で下矢印キーを押すと、最下行ではなくゴミ箱にフォーカスが移動していました。

## 修正内容

下矢印キーでのフォーカス移動を正しい仕様に修正しました：

1. **最下行にいる場合**：そのままゴミ箱に移動（ゴミ箱がない場合は移動しない）
2. **最下行2行目にいる場合**：
   - 2-1. 下の行（最下行）に画像またはピンがある場合：同じ列の最下行に移動
   - 2-2. ない場合：ピンに移動

## 動作例

グリッドが4列で画像が10枚ある場合：

行1: 0   1   2   3
行2: 4   5   6   7   ← 最下行2行目
行3: 8   9   📍     ← 最下行

- インデックス4（行2）→ インデックス8（行3の同じ列）
- インデックス5（行2）→ インデックス9（行3の同じ列）
- インデックス6（行2）→ 📍（下に同じ列がないため）
- インデックス7（行2）→ 📍（下に同じ列がないため）
- インデックス8, 9, 📍（行3=最下行）→ ゴミ箱

fixes #31