### PR TITLE
ゴミ箱のキーボードナビゲーションで自動スクロールを有効化

### DIFF
--- a/arrange-gui/src/App.jsx
+++ b/arrange-gui/src/App.jsx
@@ -94,6 +94,16 @@ function App() {
     }
   }, [focusIndex, activeArea]);
 
+  // Auto-scroll to focused item in trash
+  useEffect(() => {
+    if (activeArea === 'trash') {
+      const el = document.getElementById(`trash-tile-${trashFocusIndex}`);
+      if (el) {
+        el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      }
+    }
+  }, [trashFocusIndex, activeArea]);
+
   // Calculate auto-fit size when images load or trash visibility changes
   useEffect(() => {
     if (!autoZoomMode) return;


### PR DESCRIPTION
## 概要
ゴミ箱内の画像をキーボードの矢印キーで移動する際に、自動的に横スクロールするようにしました。

## 変更内容
- ゴミ箱のフォーカスされた画像が自動的にビューにスクロールされるようになりました
- メインエリアと同じ `scrollIntoView` の動作を実装しました

## 修正した問題
Fixes #34

## テスト
- 複数の画像をゴミ箱に移動
- 左右の矢印キーでナビゲーション
- フォーカスされた画像が自動的にビューにスクロールされることを確認