### PR TITLE
バグ修正：縦移動が実際のグリッド列数と一致するように修正

### DIFF
--- a/arrange-gui/package-lock.json
+++ b/arrange-gui/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "^1.58.2",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
@@ -1010,13 +1010,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2565,13 +2565,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/arrange-gui/package.json
+++ b/arrange-gui/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.58.2",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",

--- a/arrange-gui/src/App.jsx
+++ b/arrange-gui/src/App.jsx
@@ -39,6 +39,7 @@ function App() {
 
   const fileInputRef = useRef(null);
   const containerRef = useRef(null);
+  const gridRef = useRef(null);
 
   // Calculate grid columns based on container width
   const [gridColumns, setGridColumns] = useState(8);
@@ -73,16 +74,27 @@ function App() {
 
   useEffect(() => {
     const updateColumns = () => {
-      if (containerRef.current) {
-        const containerWidth = containerRef.current.offsetWidth - 40; // padding
-        const cols = Math.floor(containerWidth / (imageSize + 8)); // gap
-        setGridColumns(Math.max(1, cols));
+      if (gridRef.current && images.length > 0) {
+        const tiles = gridRef.current.querySelectorAll('.image-tile:not(.dummy-tile)');
+        if (tiles.length >= 2) {
+          const firstTile = tiles[0];
+          const firstTop = firstTile.offsetTop;
+          let cols = 1;
+          for (let i = 1; i < tiles.length; i++) {
+            if (tiles[i].offsetTop === firstTop) {
+              cols++;
+            } else {
+              break;
+            }
+          }
+          setGridColumns(Math.max(1, cols));
+        }
       }
     };
     updateColumns();
     window.addEventListener('resize', updateColumns);
     return () => window.removeEventListener('resize', updateColumns);
-  }, [imageSize]);
+  }, [imageSize, images.length]);
 
   // Auto-scroll to focused item
   useEffect(() => {
@@ -639,6 +651,7 @@ function App() {
           </div>
         ) : (
           <ImageGrid
+            ref={gridRef}
             images={images}
             focusIndex={activeArea === 'main' ? focusIndex : -1}
             selectedIndices={selectedIndices}

--- a/arrange-gui/src/components/ImageGrid.jsx
+++ b/arrange-gui/src/components/ImageGrid.jsx
@@ -1,7 +1,8 @@
 import './ImageGrid.css';
 import ImageTile from './ImageTile';
+import { forwardRef } from 'react';
 
-function ImageGrid({
+const ImageGrid = forwardRef(({
     images,
     focusIndex,
     selectedIndices,
@@ -9,9 +10,10 @@ function ImageGrid({
     mainImageId,
     tabImageId,
     imageSize,
-}) {
+}, ref) => {
     return (
         <div
+            ref={ref}
             className="image-grid"
             style={{
                 '--image-size': `${imageSize}px`,
@@ -41,6 +43,8 @@ function ImageGrid({
             </div>
         </div>
     );
-}
+});
+
+ImageGrid.displayName = 'ImageGrid';
 
 export default ImageGrid;

--- a/arrange-gui/tests/sticker-gui.spec.js
+++ b/arrange-gui/tests/sticker-gui.spec.js
@@ -122,4 +122,44 @@ test.describe('Sticker GUI (English)', () => {
         // After reset, size should be recalculated to fit all images
         expect(resetSize).toBeLessThan(manualSize); // Should be smaller to fit more images
     });
+
+    test('should navigate vertically matching actual grid columns (issue #33)', async ({ page }) => {
+        // Upload 20 images to test vertical navigation
+        const files = Array.from({ length: 20 }, (_, i) => ({
+            name: `sticker${i}.png`,
+            mimeType: 'image/png',
+            buffer: createDummyPng(),
+        }));
+        await page.locator('input[type="file"]').setInputFiles(files);
+        await expect(page.locator('.image-tile:not(.dummy-tile)')).toHaveCount(20);
+
+        // Click first tile to focus
+        await page.locator('.image-tile').first().click();
+        await expect(page.locator('.image-tile').first()).toHaveClass(/focused/);
+
+        // Get the actual number of columns by checking tile positions
+        const tiles = page.locator('.image-tile:not(.dummy-tile)');
+        const firstTop = await tiles.nth(0).evaluate(el => el.offsetTop);
+        let actualColumns = 1;
+        for (let i = 1; i < 20; i++) {
+            const top = await tiles.nth(i).evaluate(el => el.offsetTop);
+            if (top === firstTop) {
+                actualColumns++;
+            } else {
+                break;
+            }
+        }
+
+        // Press down arrow - should move by actualColumns positions
+        await page.keyboard.press('ArrowDown');
+        await expect(tiles.nth(actualColumns)).toHaveClass(/focused/);
+
+        // Press down again - should move by actualColumns positions again
+        await page.keyboard.press('ArrowDown');
+        await expect(tiles.nth(actualColumns * 2)).toHaveClass(/focused/);
+
+        // Press up - should move back by actualColumns positions
+        await page.keyboard.press('ArrowUp');
+        await expect(tiles.nth(actualColumns)).toHaveClass(/focused/);
+    });
 });


### PR DESCRIPTION
## 概要

上下矢印キーによる縦移動が、実際に表示されているグリッドの列数と一致していなかった問題を修正しました。

## 問題

- 横に9枚並んでいるときに、上下矢印キーを押すと8枚分移動していた
- これにより、同じ列の上下ではなく、斜めに移動していた
- 例：1枚目から下矢印を押すと、10枚目ではなく9枚目に移動していた

## 原因

JavaScriptで計算した `gridColumns` の値が、CSSグリッドの実際のレイアウトと一致していなかった。

- CSS: `repeat(auto-fill, var(--image-size))` でブラウザが自動計算
- JavaScript: `Math.floor(containerWidth / (imageSize + 8))` で手動計算
- 丸め誤差やタイミングの違いにより、両者が異なる値になることがあった

## 修正内容

- `ImageGrid` コンポーネントに `forwardRef` を追加してグリッド要素を公開
- `App.jsx` で実際にレンダリングされたタイルの位置（`offsetTop`）を調べて、実際の列数を取得するように変更
- Playwright テストを追加して、縦移動が実際のグリッドレイアウトと一致することを確認

## テスト結果

すべてのPlaywrightテスト（7件）が成功しました。

Fixes #33